### PR TITLE
Use grid_area to calculate rrfac instead of a distance

### DIFF
--- a/calc_rrfac.py
+++ b/calc_rrfac.py
@@ -32,28 +32,13 @@ args = parser.parse_args()
 scrip = Dataset(args.scrip, 'r+')
 
 grid_size = scrip.dimensions['grid_size'].size
+grid_area = scrip.variables['grid_area'][:]
 
-grid_center_lat = scrip.variables['grid_center_lat'][:]
-grid_center_lon = scrip.variables['grid_center_lon'][:]
-grid_corner_lat = scrip.variables['grid_corner_lat'][:]
-grid_corner_lon = scrip.variables['grid_corner_lon'][:]
-
-grid_dt = np.array(grid_center_lat)
-max_dt = 0
-
-for i in range(grid_size):
-        grid_dt[i]  = sphere_distance(grid_center_lat[i], grid_center_lon[i],
-                                      grid_corner_lat[i][0], grid_corner_lon[i][0],
-                                      1.0) * 2.0
-        if grid_dt[i] > max_dt:
-                max_dt = grid_dt[i]
-
-
-print("MAX grid_dt: ", grid_dt[i])
-
-# Calculate rrfac using grid_dt
+# Calculate rrfac using grid_area
 rrfac = np.array(grid_size)
-rrfac = max_dt / grid_dt[:]
+max_area = max(grid_area)
+rrfac = max_area / grid_area[:]
+rrfac = np.sqrt(rrfac)
 max_rrfac = max(rrfac)
 
 if not 'rrfac' in scrip.variables:


### PR DESCRIPTION
Using the grid_area to calculate rrfac rather than an approximate grid distance
appears to give a better result of the actually refinement factor of cells. The
grid distance calculation (grid center to one grid corner) might not as
accurately as using the grid_area field.